### PR TITLE
Support variable substitution in the root object name

### DIFF
--- a/src/main/java/br/com/ingenieux/jenkins/plugins/awsebdeployment/Deployer.java
+++ b/src/main/java/br/com/ingenieux/jenkins/plugins/awsebdeployment/Deployer.java
@@ -97,7 +97,7 @@ public class Deployer {
 		this.listener = listener;
 		
 		this.rootFileObject = new FilePath(build.getWorkspace(),
-				strip(context.getRootObject()));
+				getValue(context.getRootObject()));
 	}
 
 	public void perform() throws Exception {


### PR DESCRIPTION
We use the plugin with a parameterized build that allows the user select the version to be deployed.  The war file is downloaded from Nexus and we need to use the version number variable in the root object name.
