### PR TITLE
Added opt-out of the actual awseb deploy

### DIFF
--- a/src/main/java/br/com/ingenieux/jenkins/plugins/awsebdeployment/AWSEBDeploymentBuilder.java
+++ b/src/main/java/br/com/ingenieux/jenkins/plugins/awsebdeployment/AWSEBDeploymentBuilder.java
@@ -52,7 +52,7 @@ public class AWSEBDeploymentBuilder extends Builder implements BuildStep {
 			String awsSecretSharedKey, String awsRegion,
 			String applicationName, String environmentName, String bucketName,
 			String keyPrefix, String versionLabelFormat, String rootObject,
-			String includes, String excludes) {
+			String includes, String excludes, boolean deployOptOut) {
 		super();
 		this.awsAccessKeyId = awsAccessKeyId;
 		this.awsSecretSharedKey = awsSecretSharedKey;
@@ -65,6 +65,7 @@ public class AWSEBDeploymentBuilder extends Builder implements BuildStep {
 		this.rootObject = rootObject;
 		this.includes = includes;
 		this.excludes = excludes;
+		this.deployOptOut = deployOptOut;
 	}
 
 	/**
@@ -197,6 +198,16 @@ public class AWSEBDeploymentBuilder extends Builder implements BuildStep {
 	public void setExcludes(String excludes) {
 		this.excludes = excludes;
 	}
+
+	private boolean deployOptOut;
+
+    public boolean getDeployOptOut() {
+    	return deployOptOut;
+    }
+
+    public void setDeployOptOut(boolean deployOptOut) {
+    	this.deployOptOut = deployOptOut;
+    }
 
 	@Override
 	public boolean perform(AbstractBuild<?, ?> build, Launcher launcher,
@@ -366,6 +377,15 @@ public class AWSEBDeploymentBuilder extends Builder implements BuildStep {
     		this.excludes = excludes;
     	}
 
+		private boolean deployOptOut;
+
+		public boolean getDeployOptOut() {
+			return deployOptOut;
+		}
+
+		public void setDeployOptOut(boolean deployOptOut) {
+			this.deployOptOut = deployOptOut;
+		}
 
         /**
          * In order to load the persisted global configuration, you have to 

--- a/src/main/java/br/com/ingenieux/jenkins/plugins/awsebdeployment/Deployer.java
+++ b/src/main/java/br/com/ingenieux/jenkins/plugins/awsebdeployment/Deployer.java
@@ -111,7 +111,9 @@ public class Deployer {
 
 		createApplicationVersion();
 
-		updateEnvironments();
+		if (!context.getDeployOptOut()) {
+			updateEnvironments();
+		}
 
 		listener.finished(Result.SUCCESS);
 

--- a/src/main/resources/br/com/ingenieux/jenkins/plugins/awsebdeployment/AWSEBDeploymentBuilder/config.jelly
+++ b/src/main/resources/br/com/ingenieux/jenkins/plugins/awsebdeployment/AWSEBDeploymentBuilder/config.jelly
@@ -42,4 +42,7 @@
   <f:entry title="Environment Name" field="environmentName">
     <f:textbox />
   </f:entry>
+  <f:entry title="Do not deploy to awseb" field="deployOptOut">
+    <f:checkbox />
+  </f:entry>
 </j:jelly>

--- a/src/main/resources/br/com/ingenieux/jenkins/plugins/awsebdeployment/AWSEBDeploymentBuilder/help-deployOptOut.html
+++ b/src/main/resources/br/com/ingenieux/jenkins/plugins/awsebdeployment/AWSEBDeploymentBuilder/help-deployOptOut.html
@@ -1,0 +1,22 @@
+<!--
+  #%L
+  AWS Elastic Beanstalk Deployment Plugin
+  %%
+  Copyright (C) 2013 ingenieux Labs
+  %%
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+       http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+<div>
+  Check if you want do not want to automatically deploy the new version to your awseb environment.
+</div>


### PR DESCRIPTION
Completely and utterly untested code.

Added an opt-out from awseb checkbox.
If checked, it will skip the "updateEnvironment" call.
The addition leaves current settings and behaviour untouched as the default state (unchecked) will not change anything.

This is the first time I've ever written anything in a Jenkins plugin so I'm not sure if the checkbox handling in the builder (boolean) will work.
