### PR TITLE
Changing the AWS Region to use the Regions enum instead of a raw string

### DIFF
--- a/src/main/java/br/com/ingenieux/jenkins/plugins/awsebdeployment/AWSEBDeploymentBuilder.java
+++ b/src/main/java/br/com/ingenieux/jenkins/plugins/awsebdeployment/AWSEBDeploymentBuilder.java
@@ -42,14 +42,15 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
 
+import com.amazonaws.regions.Regions;
+
 /**
  * AWS Elastic Beanstalk Deployment
  */
-@SuppressWarnings({ "unchecked" })
 public class AWSEBDeploymentBuilder extends Builder implements BuildStep {
 	@DataBoundConstructor
 	public AWSEBDeploymentBuilder(String awsAccessKeyId,
-			String awsSecretSharedKey, String awsRegion,
+			String awsSecretSharedKey, Regions awsRegion,
 			String applicationName, String environmentName, String bucketName,
 			String keyPrefix, String versionLabelFormat, String rootObject,
 			String includes, String excludes) {
@@ -96,16 +97,16 @@ public class AWSEBDeploymentBuilder extends Builder implements BuildStep {
 	/**
 	 * AWS Region
 	 */
-	private String awsRegion;
+	private Regions awsRegion;
 
-	public String getAwsRegion() {
+	public Regions getAwsRegion() {
 		return awsRegion;
 	}
 
-	public void setAwsRegion(String awsRegion) {
+	public void setAwsRegion(Regions awsRegion) {
 		this.awsRegion = awsRegion;
 	}
-
+	
 	/**
 	 * Application Name
 	 */

--- a/src/main/java/br/com/ingenieux/jenkins/plugins/awsebdeployment/Deployer.java
+++ b/src/main/java/br/com/ingenieux/jenkins/plugins/awsebdeployment/Deployer.java
@@ -203,8 +203,7 @@ public class Deployer {
 				new StaticCredentialsProvider(new BasicAWSCredentials(
 						context.getAwsAccessKeyId(),
 						context.getAwsSecretSharedKey())));
-		Region region = Region.getRegion(Regions.fromName(context
-				.getAwsRegion()));
+		Region region = Region.getRegion(context.getAwsRegion());
 		ClientConfiguration clientConfig = new ClientConfiguration();
 
 		clientConfig.setUserAgent("ingenieux CloudButler/" + getVersion());

--- a/src/main/resources/br/com/ingenieux/jenkins/plugins/awsebdeployment/AWSEBDeploymentBuilder/config.jelly
+++ b/src/main/resources/br/com/ingenieux/jenkins/plugins/awsebdeployment/AWSEBDeploymentBuilder/config.jelly
@@ -16,7 +16,9 @@
     <f:textbox />
   </f:entry>
   <f:entry title="AWS Region" field="awsRegion">
-    <f:textbox />
+    <f:enum field="awsRegion">
+    	${it.getName()}
+    </f:enum>
   </f:entry>
   <f:entry title="Application Name" field="applicationName">
     <f:textbox />


### PR DESCRIPTION
I was being silly when I started using this plugin and typed in the wrong value for the region, and the error message didn't make any sense.  The stack trace reported it couldn't turn the region into an enum.  
