### PR TITLE
allows lookup of Environment by ID

### DIFF
--- a/src/main/java/br/com/ingenieux/jenkins/plugins/awsebdeployment/AWSEBDeploymentBuilder.java
+++ b/src/main/java/br/com/ingenieux/jenkins/plugins/awsebdeployment/AWSEBDeploymentBuilder.java
@@ -376,17 +376,31 @@ public class AWSEBDeploymentBuilder extends Builder implements BuildStep {
                     clientFactory.getService(AWSElasticBeanstalkClient.class);
 
             DescribeEnvironmentsResult
-                    describeEnvironmentsResult =
+                    describeEnvironmentsResultForName =
                     awsElasticBeanstalk.describeEnvironments(
                             new DescribeEnvironmentsRequest().withApplicationName(applicationName)
                                     .withIncludeDeleted(false)
                                     .withEnvironmentNames(environmentName));
 
-            if (1 == describeEnvironmentsResult.getEnvironments().size()) {
+            if (1 == describeEnvironmentsResultForName.getEnvironments().size()) {
                 String
                         environmentId =
-                        describeEnvironmentsResult.getEnvironments().get(0).getEnvironmentId();
+                        describeEnvironmentsResultForName.getEnvironments().get(0).getEnvironmentId();
                 return FormValidation.ok("Environment found (environmentId: %s)", environmentId);
+            }
+
+            DescribeEnvironmentsResult
+                    describeEnvironmentsResultForId =
+                    awsElasticBeanstalk.describeEnvironments(
+                            new DescribeEnvironmentsRequest().withApplicationName(applicationName)
+                                    .withIncludeDeleted(false)
+                                    .withEnvironmentIds(environmentName));
+
+            if (1 == describeEnvironmentsResultForId.getEnvironments().size()) {
+                String
+                        envName =
+                        describeEnvironmentsResultForId.getEnvironments().get(0).getEnvironmentName();
+                return FormValidation.ok("Environment found (environmentName: %s)", envName);
             }
 
             return FormValidation.error("Environment not found");

--- a/src/main/java/br/com/ingenieux/jenkins/plugins/awsebdeployment/cmd/ZeroDowntime.java
+++ b/src/main/java/br/com/ingenieux/jenkins/plugins/awsebdeployment/cmd/ZeroDowntime.java
@@ -164,7 +164,7 @@ public class ZeroDowntime extends DeployerCommand {
                         .withIncludeDeleted(false));
 
         for (EnvironmentDescription env : environments.getEnvironments()) {
-            if (environmentNames.contains(env.getEnvironmentName())) {
+            if (environmentNames.contains(env.getEnvironmentName()) || environmentNames.contains(env.getEnvironmentId())) {
                 if (WORKER_ENVIRONMENT_TYPE.equals(env.getTier().getName())) {
                     throw new InvalidDeploymentTypeException();
                 }

--- a/src/main/resources/br/com/ingenieux/jenkins/plugins/awsebdeployment/AWSEBDeploymentBuilder/config.jelly
+++ b/src/main/resources/br/com/ingenieux/jenkins/plugins/awsebdeployment/AWSEBDeploymentBuilder/config.jelly
@@ -43,7 +43,7 @@
             <f:textbox/>
         </f:entry>
 
-        <f:entry title="Environment Name" field="environmentName">
+        <f:entry title="Environment Name/ID" field="environmentName">
             <f:textbox/>
         </f:entry>
 

--- a/src/main/resources/br/com/ingenieux/jenkins/plugins/awsebdeployment/AWSEBDeploymentBuilder/help-environmentName.html
+++ b/src/main/resources/br/com/ingenieux/jenkins/plugins/awsebdeployment/AWSEBDeploymentBuilder/help-environmentName.html
@@ -15,5 +15,5 @@
   -->
 
 <div>
-  Optional: AWS EB Environment Name for the Application (e.g.: "myapp-prod-env"). When set and Environment Name exists, it will trigger a UpdateEnvironment Call when the Application Version is created.
+  Optional: AWS EB Environment Name or ID for the Application (e.g.: "myapp-prod-env"). When set and Environment exists, it will trigger a UpdateEnvironment Call when the Application Version is created.
 </div>


### PR DESCRIPTION
Lets the plugin lookup an environment by ID and not just name. This allows fixes and issue with the ZeroDowntime option needing updating at every deployment as the name gets changed on each iteration