### PR TITLE
Make build step fail upon aborted deployment.

### DIFF
--- a/src/main/java/br/com/ingenieux/jenkins/plugins/awsebdeployment/SlaveDeployerCallable.java
+++ b/src/main/java/br/com/ingenieux/jenkins/plugins/awsebdeployment/SlaveDeployerCallable.java
@@ -39,6 +39,9 @@ public class SlaveDeployerCallable extends MasterToSlaveCallable<Boolean, Except
   public Boolean call() throws Exception {
     DeployerChain deployerChain = new DeployerChain(deployerContext);
 
-    return deployerChain.perform();
+    if (deployerChain.perform()) {
+      throw new Exception("Deployment aborted");
+    };
+    return false;
   }
 }


### PR DESCRIPTION
Throw an error if a deployer command returns true.
Current behaviour is for the deployment to be aborted, but the jenkins build step is marked as successful.