### PR TITLE
Added Extra Handling for AF* Region (af-sout-1, south africa)

### DIFF
--- a/src/main/java/br/com/ingenieux/jenkins/plugins/awsebdeployment/AWSClientFactory.java
+++ b/src/main/java/br/com/ingenieux/jenkins/plugins/awsebdeployment/AWSClientFactory.java
@@ -152,6 +152,14 @@ public class AWSClientFactory implements Constants {
             }
         }
 
+        // Extra Handling for AF* Region
+        if (region.startsWith("af-")) {
+            if (endpointStr.matches("s3-af-\\p{Alpha}+-\\d.amazonaws.com")) {
+                endpointStr = endpointStr.replaceFirst("s3-af-", "s3.af-");
+            }
+        }
+
+
         return endpointStr;
     }
 


### PR DESCRIPTION
Added a fix to cater for the recently launched region in Africa(Cape Town) named "af-south-1". 

Regional Endpoint: **s3.af-south-1.amazonaws.com**