### PR TITLE
Lookup credentials on server in case job runs on remote node

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.19</version>
+        <version>4.37</version>
         <relativePath />
     </parent>
 
@@ -32,8 +32,10 @@
     <url>https://wiki.jenkins-ci.org/display/JENKINS/AWSEB+Deployment+Plugin</url>
 
     <properties>
-        <java.level>7</java.level>
-        <jenkins.version>2.121.3</jenkins.version>
+        <jenkins.version>2.289.3</jenkins.version>
+        <java.level>8</java.level>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
 
     <licenses>
@@ -92,19 +94,12 @@
                 </configuration>
             </plugin>
             <plugin>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.2</version>
-                <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
-                </configuration>
-            </plugin>
-            <plugin>
                 <groupId>org.jenkins-ci.tools</groupId>
                 <artifactId>maven-hpi-plugin</artifactId>
                 <extensions>true</extensions>
                 <configuration>
-                    <compatibleSinceVersion>0.0.4</compatibleSinceVersion>
+                    <compatibleSinceVersion>1.45</compatibleSinceVersion>
+                    <minimumJavaVersion>8</minimumJavaVersion>
                 </configuration>
             </plugin>
         </plugins>
@@ -114,24 +109,29 @@
         <connection>scm:git:ssh://github.com/ingenieux/awseb-deployment-plugin.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/ingenieux/awseb-deployment-plugin.git</developerConnection>
         <url>https://wiki.jenkins-ci.org/display/JENKINS/AWSEB+Deployment+Plugin</url>
-        <tag>awseb-deployment-plugin-0.3.8</tag>
+        <tag>awseb-deployment-plugin-0.3.22</tag>
     </scm>
 
     <dependencies>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>aws-credentials</artifactId>
-            <version>1.23</version>
+            <version>189.v3551d5642995</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>aws-java-sdk</artifactId>
-            <version>1.11.341</version>
+            <version>1.12.70</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>token-macro</artifactId>
-            <version>2.1</version>
+            <version>2.15</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci</groupId>
+            <artifactId>symbol-annotation</artifactId>
+            <version>1.23</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.main</groupId>
@@ -141,7 +141,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.16.6</version>
+            <version>1.18.24</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/br/com/ingenieux/jenkins/plugins/awsebdeployment/AWSEBDeploymentBuilder.java
+++ b/src/main/java/br/com/ingenieux/jenkins/plugins/awsebdeployment/AWSEBDeploymentBuilder.java
@@ -50,10 +50,7 @@ import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -69,7 +66,6 @@ import static org.apache.commons.lang.StringUtils.defaultIfBlank;
  */
 @SuppressWarnings({"unchecked", "deprecation"})
 public class AWSEBDeploymentBuilder extends Builder implements SimpleBuildStep {
-    private static final Logger LOGGER = LoggerFactory.getLogger(AWSEBDeploymentBuilder.class);
 
     @Getter
     private AWSEBDeploymentConfig config;
@@ -237,8 +233,7 @@ public class AWSEBDeploymentBuilder extends Builder implements SimpleBuildStep {
     }
 
     @Override
-    public void perform(@Nonnull Run<?, ?> build, @Nonnull FilePath ws, @Nonnull Launcher launcher,
-                        @Nonnull TaskListener listener) throws IOException {
+    public void perform(Run<?, ?> build, FilePath ws, Launcher launcher, TaskListener listener) throws IOException {
         try {
             new DeployerRunner(build, ws, launcher, listener, this).perform();
         } catch (Exception exc) {

--- a/src/main/java/br/com/ingenieux/jenkins/plugins/awsebdeployment/AWSEBDeploymentCredentials.java
+++ b/src/main/java/br/com/ingenieux/jenkins/plugins/awsebdeployment/AWSEBDeploymentCredentials.java
@@ -1,0 +1,31 @@
+package br.com.ingenieux.jenkins.plugins.awsebdeployment;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.BasicAWSCredentials;
+import lombok.Data;
+
+import java.io.Serializable;
+
+@Data
+public class AWSEBDeploymentCredentials implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    public AWSEBDeploymentCredentials(String awsAccessKeyId, String awsSecretKey) {
+        this.awsAccessKeyId = awsAccessKeyId;
+        this.awsSecretKey = awsSecretKey;
+    }
+
+    /**
+     * Access Key ID of credential
+     */
+    String awsAccessKeyId;
+
+    /**
+     * Secret Key of credential
+     */
+    String awsSecretKey;
+
+    public AWSCredentials toAWSCredentials() {
+        return new BasicAWSCredentials(awsAccessKeyId, awsSecretKey);
+    }
+}

--- a/src/main/java/br/com/ingenieux/jenkins/plugins/awsebdeployment/DeployerRunner.java
+++ b/src/main/java/br/com/ingenieux/jenkins/plugins/awsebdeployment/DeployerRunner.java
@@ -17,19 +17,24 @@
 package br.com.ingenieux.jenkins.plugins.awsebdeployment;
 
 import br.com.ingenieux.jenkins.plugins.awsebdeployment.cmd.DeployerContext;
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
 import hudson.FilePath;
 import hudson.Launcher;
+import hudson.ProxyConfiguration;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.remoting.Future;
 import hudson.remoting.VirtualChannel;
+import jenkins.model.Jenkins;
 import org.jenkinsci.plugins.tokenmacro.MacroEvaluationException;
 
 import java.io.IOException;
 
-public class DeployerRunner {
-    private final Run<?, ?> build;
+import static org.apache.commons.lang.StringUtils.isNotBlank;
 
+public class DeployerRunner {
     private final Launcher launcher;
 
     private final TaskListener listener;
@@ -38,8 +43,7 @@ public class DeployerRunner {
 
     private final AWSEBDeploymentConfig config;
 
-    DeployerRunner(Run<?, ?> build, FilePath ws, Launcher launcher, TaskListener listener, AWSEBDeploymentBuilder deploymentBuilder) throws InterruptedException, MacroEvaluationException, IOException {
-        this.build = build;
+    DeployerRunner(Run<?, ?> build, FilePath ws, Launcher launcher, TaskListener listener, AWSEBDeploymentBuilder deploymentBuilder) throws InterruptedException, IOException, MacroEvaluationException {
         this.launcher = launcher;
         this.listener = listener;
         this.workspace = ws;
@@ -49,8 +53,21 @@ public class DeployerRunner {
     public boolean perform() throws Exception {
         FilePath rootFileObject = new FilePath(this.workspace, config.getRootObject());
 
-        final DeployerContext
-                deployerContext = new DeployerContext(config, rootFileObject, listener);
+        AWSCredentialsProvider provider = new DefaultAWSCredentialsProviderChain();
+
+        String credentialsId = config.getCredentialId();
+        if (isNotBlank(credentialsId)) {
+            provider = AWSClientFactory.lookupNamedCredential(credentialsId);
+        }
+
+        AWSCredentials awsCredentials = provider.getCredentials();
+        if(awsCredentials == null) {
+            throw new IllegalStateException("Could not determine AWS credentials.");
+        }
+        AWSEBDeploymentCredentials credentials = new AWSEBDeploymentCredentials(awsCredentials.getAWSAccessKeyId(), awsCredentials.getAWSSecretKey());
+
+        ProxyConfiguration proxy = Jenkins.get().getProxy();
+        DeployerContext deployerContext = new DeployerContext(config, rootFileObject, listener, credentials, proxy);
 
         final VirtualChannel channel = launcher.getChannel();
 

--- a/src/main/java/br/com/ingenieux/jenkins/plugins/awsebdeployment/Utils.java
+++ b/src/main/java/br/com/ingenieux/jenkins/plugins/awsebdeployment/Utils.java
@@ -20,12 +20,10 @@
 package br.com.ingenieux.jenkins.plugins.awsebdeployment;
 
 import hudson.FilePath;
-import hudson.model.AbstractBuild;
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.tokenmacro.MacroEvaluationException;
 import org.jenkinsci.plugins.tokenmacro.TokenMacro;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Properties;

--- a/src/main/java/br/com/ingenieux/jenkins/plugins/awsebdeployment/cmd/DeployerCommand.java
+++ b/src/main/java/br/com/ingenieux/jenkins/plugins/awsebdeployment/cmd/DeployerCommand.java
@@ -19,12 +19,16 @@ package br.com.ingenieux.jenkins.plugins.awsebdeployment.cmd;
 import br.com.ingenieux.jenkins.plugins.awsebdeployment.AWSClientFactory;
 import br.com.ingenieux.jenkins.plugins.awsebdeployment.Constants;
 import br.com.ingenieux.jenkins.plugins.awsebdeployment.Utils;
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.services.elasticbeanstalk.AWSElasticBeanstalkClient;
 import com.amazonaws.services.elasticbeanstalk.model.*;
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.util.VersionInfoUtils;
 import com.google.common.collect.Sets;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import hudson.ProxyConfiguration;
 import hudson.Util;
 import lombok.Data;
 import lombok.experimental.Delegate;
@@ -138,11 +142,13 @@ public class DeployerCommand implements Constants {
     public static class InitAWS extends DeployerCommand {
         @Override
         public boolean perform() throws Exception {
-            AWSClientFactory factory;
+            AWSCredentials credentials = c.getCredentials().toAWSCredentials();
+            AWSStaticCredentialsProvider provider = new AWSStaticCredentialsProvider(credentials);
 
-            factory = AWSClientFactory.getClientFactory(getConfig().getCredentialId(), getConfig().getAwsRegion());
+            String region = getConfig().getAwsRegion();
+            AWSClientFactory factory = AWSClientFactory.getClientFactory(provider, region, c.getProxy());
 
-            log("Using region: '%s'", getConfig().getAwsRegion());
+            log("Using region: '%s'", region);
 
             setS3(factory.getService(AmazonS3Client.class));
             setAwseb(factory.getService(AWSElasticBeanstalkClient.class));

--- a/src/main/java/br/com/ingenieux/jenkins/plugins/awsebdeployment/cmd/DeployerContext.java
+++ b/src/main/java/br/com/ingenieux/jenkins/plugins/awsebdeployment/cmd/DeployerContext.java
@@ -17,10 +17,12 @@
 package br.com.ingenieux.jenkins.plugins.awsebdeployment.cmd;
 
 import br.com.ingenieux.jenkins.plugins.awsebdeployment.AWSEBDeploymentConfig;
+import br.com.ingenieux.jenkins.plugins.awsebdeployment.AWSEBDeploymentCredentials;
 import br.com.ingenieux.jenkins.plugins.awsebdeployment.Constants;
 import com.amazonaws.services.elasticbeanstalk.AWSElasticBeanstalk;
 import com.amazonaws.services.s3.AmazonS3;
 import hudson.FilePath;
+import hudson.ProxyConfiguration;
 import hudson.model.TaskListener;
 import lombok.Data;
 
@@ -37,6 +39,11 @@ public class DeployerContext implements Constants, Serializable {
     final AWSEBDeploymentConfig config;
 
     /**
+     * Deployer Credentials
+     */
+    final AWSEBDeploymentCredentials credentials;
+
+    /**
      * Root File Object
      */
     final FilePath rootFileObject;
@@ -46,10 +53,16 @@ public class DeployerContext implements Constants, Serializable {
      */
     final TaskListener listener;
 
-    public DeployerContext(AWSEBDeploymentConfig config, FilePath rootFileObject, TaskListener listener) {
+    public DeployerContext(AWSEBDeploymentConfig config,
+                           FilePath rootFileObject,
+                           TaskListener listener,
+                           AWSEBDeploymentCredentials credentials,
+                           ProxyConfiguration proxy) {
         this.config = config;
         this.rootFileObject = rootFileObject;
         this.listener = listener;
+        this.credentials = credentials;
+        this.proxy = proxy;
     }
 
     /**
@@ -66,6 +79,11 @@ public class DeployerContext implements Constants, Serializable {
      * Logger Object
      */
     transient PrintStream logger;
+
+    /**
+     * Proxy Configuration
+     */
+    ProxyConfiguration proxy;
 
     /**
      * <p>


### PR DESCRIPTION
On a remote node the configuration or credential store
of Jenkins is not available. This gathers all values
before hand and provides them via the context.

This fixes #96 